### PR TITLE
Make mongo_fdw work on PostgreSQL version 9.2.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.o
+mongo_fdw.so
+


### PR DESCRIPTION
That is a simple solution to make the mongo_fdw work on PostgreSQL 9.2.
There is no performance improvements that the 9.2 version provided, like
better estimate plans. Basically we created the MongoGetForeignRelSize
function based on old MongoPlanForeignScan (encapsulating the calls on
MongoGeneratePlanState function), and basic (dummy) MongoGetForeignPaths
and MongoGetForeignPlan functions (based on file_fdw).
