### PR TITLE
Fix build under Postgres 9.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,18 +19,8 @@ OBJS = mongo_fdw.o mongo_query.o $(MONGO_OBJS)
 EXTENSION = mongo_fdw
 DATA = mongo_fdw--1.0.sql
 
-#
-# We first build our dependency, the Mongo C driver library here. For this, we
-# explicitly invoke the subdirectory's make system.
-#
-
-all: all-mongo-driver
-all-mongo-driver:
-	$(MAKE) -C $(MONGO_DRIVER) all
-
-clean: clean-mongo-driver
-clean-mongo-driver:
-	$(MAKE) -C $(MONGO_DRIVER) clean
+$(MONGO_DRIVER)/%.os:
+	$(MAKE) -C $(MONGO_DRIVER) $*.os
 
 #
 # Users need to specify their Postgres installation path through pg_config. For


### PR DESCRIPTION
With the change to the `.SECONDARY` rule in [this commit](http://github.com/postgres/postgres/commit/1eb1dde), vanilla Postgres extension builds do not keep intermediate files.

Rather than directly defining `all` and `clean` targets, we should be following the [Postgres guidelines for making extensions](http://www.postgresql.org/docs/current/static/extend-pgxs.html) if at all possible. This is as simple as defining special variables before including the PGXS Makefile and making sure all relevant dependencies can be built if needed.
