### PR TITLE
Make mongo_fdw compatible with PostgreSQL 9.3.

### DIFF
--- a/README
+++ b/README
@@ -1,10 +1,10 @@
-MongoDB FDW for PostgreSQL 9.2
+MongoDB FDW for PostgreSQL 9.2 and PostgreSQL 9.3
 ==============================
 
 This PostgreSQL extension implements a Foreign Data Wrapper (FDW) for MongoDB.
 For an example setup that demonstrates this wrapper's use, please see
 http://www.citusdata.com/blog/51-run-sql-on-mongodb. Please also note that this
-version of mongo_fdw only works with PostgreSQL 9.2.
+version of mongo_fdw works with PostgreSQL 9.2 and PostgreSQL 9.3.
 
 
 Building

--- a/mongo_fdw.c
+++ b/mongo_fdw.c
@@ -36,6 +36,10 @@
 #include "utils/rel.h"
 #include "utils/memutils.h"
 
+#if PG_VERSION_NUM >= 90300
+	#include "access/htup_details.h"
+#endif
+
 
 /* Local functions forward declarations */
 static StringInfo OptionNamesString(Oid currentContextId);


### PR DESCRIPTION
(1) Added support for PostgreSQL 9.3.
(2) README is updated accordingly.
